### PR TITLE
fix problem where user redirected to 404 after successful login

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -17,6 +17,11 @@ module AuthenticationConcern
       @current_user.session_id = SecureRandom.hex(8)
       session[:session_id] = @current_user.session_id
       redirect_to user_path(@current_user.id)
+      puts "-- -- -- -- -- -- -- -- -- -- -- -- -- -- \nSession value is" 
+      p session[:session_id]
+      p "DB session value is "
+      p @current_user.session_id
+      puts "-- -- -- -- -- -- -- -- -- -- -- -- -- --"
     else
       redirect_to '/'
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,18 +1,20 @@
 class SessionsController < ApplicationController
   def create
   	user = User.from_omniauth(env["omniauth.auth"])
-  	puts "---------------------------------------"
-  	session[:current_user_id] = user.id 	# assign current user id from db to session[:current_user_id]
+  	helper_login(user.username, user.password_hash)
+  	# puts "---------------------------------------"
+  	# p user
+  	# session[:current_user_id] = user.id 	# assign current user id from db to session[:current_user_id]
   
-  	if session[:session_id] != nil
-  		user.session_id = session[:session_id] 	# set user session id in db
-  		puts "Session set successfully"
-  	elsif
-  		puts "Login error"
-  	end
+  	# if session[:session_id] != nil
+  	# 	user.session_id = session[:session_id] 	# set user session id in db
+  	# 	puts "Session set successfully"
+  	# elsif
+  	# 	puts "Login error"
+  	# end
 
-  	p user
-  	puts "---------------------------------------"
+  	# p user
+  	# puts "---------------------------------------"
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,13 +6,17 @@ class UsersController < ApplicationController
   end
 
   def show
-    if session[:current_session_id] != nil
+    @current_user = User.find(params[:id])
+    puts "{{{{{{{{{}}}}}}}}}{{{{{{{{{}}}}}}}}"
+    p session[:session_id]
+    if session[:session_id] != nil
       @user_surveys = Survey.where(user_id: params[:id])
       @current_user = User.find(params[:id])
       render "user_profile"
-    else
+    elsif session[:session_id] == nil
       puts "User not logged in"
       render "/errors/404"
     end
+
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,11 +15,6 @@ class User < ActiveRecord::Base
   end
 
   def self.from_omniauth(auth)
-    puts "//////////////////////////////////////////////"
-    p auth
-    puts
-    puts auth.info.email
-    puts "//////////////////////////////////////////////"
     where(provider: auth.provider, uid: auth.uid).first_or_initialize.tap do |user|
       user.provider = auth.provider
       user.uid = auth.uid


### PR DESCRIPTION
Fixed a bug where a user gets redirected to 404.html.erb instead of /users/:id after successfully logging in with OAuth.
